### PR TITLE
Ore Samples can require tools; OrePart bugfix

### DIFF
--- a/src/main/java/com/teamacronymcoders/base/materialsystem/MaterialSystem.java
+++ b/src/main/java/com/teamacronymcoders/base/materialsystem/MaterialSystem.java
@@ -105,6 +105,18 @@ public class MaterialSystem {
     public static MaterialPart getMaterialPart(String name) {
         return Optional.ofNullable(materialPartMap.get(name.toLowerCase(Locale.US))).orElse(MISSING_MATERIAL_PART);
     }
+    
+    public static void removeMaterialPart(String name) {
+        if (materialPartMap.containsKey(name)) {
+            materialPartMap.remove(name);
+        }
+    }
+    
+    public static void removeMaterialPart(MaterialPart materialPart) {
+        if (materialPartMap.containsKey(materialPart.getUnlocalizedName())) {
+            materialPartMap.remove(materialPart.getUnlocalizedName());
+        }
+    }
 
     public static boolean hasMaterialPart(MaterialPart materialPart) {
         return materialPartMap.containsKey(materialPart.getUnlocalizedName());

--- a/src/main/java/com/teamacronymcoders/base/materialsystem/MaterialSystem.java
+++ b/src/main/java/com/teamacronymcoders/base/materialsystem/MaterialSystem.java
@@ -107,15 +107,11 @@ public class MaterialSystem {
     }
     
     public static void removeMaterialPart(String name) {
-        if (materialPartMap.containsKey(name)) {
-            materialPartMap.remove(name);
-        }
+        materialPartMap.remove(name);
     }
     
     public static void removeMaterialPart(MaterialPart materialPart) {
-        if (materialPartMap.containsKey(materialPart.getUnlocalizedName())) {
-            materialPartMap.remove(materialPart.getUnlocalizedName());
-        }
+        materialPartMap.remove(materialPart.getUnlocalizedName());
     }
 
     public static boolean hasMaterialPart(MaterialPart materialPart) {

--- a/src/main/java/com/teamacronymcoders/base/materialsystem/blocks/SubBlockOreSamplePart.java
+++ b/src/main/java/com/teamacronymcoders/base/materialsystem/blocks/SubBlockOreSamplePart.java
@@ -179,7 +179,7 @@ public class SubBlockOreSamplePart extends SubBlockPart {
     public void onNeighborChange(World world, BlockPos pos, Block block, BlockPos fromPos) {
         if (!world.getBlockState(pos.down()).isSideSolid(world, pos, EnumFacing.UP)) {
             if (!requireTool){
-                spawnItemStackEntity(world, this.getItemStack().copy(), pos);
+                getBlock().dropBlockAsItem(world, pos, getBlockState(), 0);
             }
             world.setBlockToAir(pos);
         }
@@ -196,7 +196,7 @@ public class SubBlockOreSamplePart extends SubBlockPart {
             player.sendStatusMessage(new TextComponentString(activatedText), true);
             world.setBlockToAir(pos);
         } else if (!requireTool) {
-            spawnItemStackEntity(world, this.getItemStack().copy(), pos);
+            getBlock().dropBlockAsItem(world, pos, getBlockState(), 0);
             world.setBlockToAir(pos);
         }
         player.swingArm(EnumHand.MAIN_HAND);

--- a/src/main/java/com/teamacronymcoders/base/materialsystem/blocks/SubBlockOreSamplePart.java
+++ b/src/main/java/com/teamacronymcoders/base/materialsystem/blocks/SubBlockOreSamplePart.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.teamacronymcoders.base.materialsystem.parttype.OreSamplePartType.ACTIVATED_TEXT_DATA_NAME;
-import static com.teamacronymcoders.base.materialsystem.parttype.OreSamplePartType.REQUIRED_TOOL_DATA_NAME;
+import static com.teamacronymcoders.base.materialsystem.parttype.OreSamplePartType.REQUIRE_TOOL_DATA_NAME;
 import static com.teamacronymcoders.base.materialsystem.parttype.OreSamplePartType.DROP_DATA_NAME;
 
 public class SubBlockOreSamplePart extends SubBlockPart {
@@ -56,13 +56,13 @@ public class SubBlockOreSamplePart extends SubBlockPart {
 
         mod = materialUser.getMod();
         itemDrop = data.getValue(DROP_DATA_NAME, itemDrop, DataPartParsers::getString);
-        requireTool = data.getValue(REQUIRED_TOOL_DATA_NAME, requireTool, DataPartParsers::getBoolean);
+        requireTool = data.getValue(REQUIRE_TOOL_DATA_NAME, requireTool, DataPartParsers::getBool);
         activatedText = data.getValue(ACTIVATED_TEXT_DATA_NAME, activatedText, DataPartParsers::getString);
     }
 
     @Override
     public Material getMaterial() {
-        if (requireTool) { return Material.STONE; }
+        if (requireTool) { return Material.ROCK; }
         else { return Material.GROUND; }
     }
 
@@ -175,7 +175,7 @@ public class SubBlockOreSamplePart extends SubBlockPart {
     @Override
     public void onNeighborChange(World world, BlockPos pos, Block block, BlockPos fromPos) {
         if (!world.getBlockState(pos.down()).isSideSolid(world, pos, EnumFacing.UP)) {
-            spawnItemStackEntity(world, this.getItemStack().copy(), pos);
+            if (!requireTool){ spawnItemStackEntity(world, this.getItemStack().copy(), pos); }
             world.setBlockToAir(pos);
         }
     }

--- a/src/main/java/com/teamacronymcoders/base/materialsystem/blocks/SubBlockOreSamplePart.java
+++ b/src/main/java/com/teamacronymcoders/base/materialsystem/blocks/SubBlockOreSamplePart.java
@@ -62,8 +62,11 @@ public class SubBlockOreSamplePart extends SubBlockPart {
 
     @Override
     public Material getMaterial() {
-        if (requireTool) { return Material.ROCK; }
-        else { return Material.GROUND; }
+        if (requireTool) {
+            return Material.ROCK;
+        } else {
+            return Material.GROUND;
+        }
     }
 
     @Override
@@ -175,7 +178,9 @@ public class SubBlockOreSamplePart extends SubBlockPart {
     @Override
     public void onNeighborChange(World world, BlockPos pos, Block block, BlockPos fromPos) {
         if (!world.getBlockState(pos.down()).isSideSolid(world, pos, EnumFacing.UP)) {
-            if (!requireTool){ spawnItemStackEntity(world, this.getItemStack().copy(), pos); }
+            if (!requireTool){
+                spawnItemStackEntity(world, this.getItemStack().copy(), pos);
+            }
             world.setBlockToAir(pos);
         }
     }

--- a/src/main/java/com/teamacronymcoders/base/materialsystem/blocks/SubBlockOreSamplePart.java
+++ b/src/main/java/com/teamacronymcoders/base/materialsystem/blocks/SubBlockOreSamplePart.java
@@ -35,11 +35,13 @@ import java.util.List;
 import java.util.Map;
 
 import static com.teamacronymcoders.base.materialsystem.parttype.OreSamplePartType.ACTIVATED_TEXT_DATA_NAME;
+import static com.teamacronymcoders.base.materialsystem.parttype.OreSamplePartType.REQUIRED_TOOL_DATA_NAME;
 import static com.teamacronymcoders.base.materialsystem.parttype.OreSamplePartType.DROP_DATA_NAME;
 
 public class SubBlockOreSamplePart extends SubBlockPart {
     private ItemStack itemStackToDrop = null;
     private String itemDrop;
+    private boolean requireTool;
     private String activatedText;
     private IBaseMod mod;
 
@@ -54,12 +56,14 @@ public class SubBlockOreSamplePart extends SubBlockPart {
 
         mod = materialUser.getMod();
         itemDrop = data.getValue(DROP_DATA_NAME, itemDrop, DataPartParsers::getString);
+        requireTool = data.getValue(REQUIRED_TOOL_DATA_NAME, requireTool, DataPartParsers::getBoolean);
         activatedText = data.getValue(ACTIVATED_TEXT_DATA_NAME, activatedText, DataPartParsers::getString);
     }
 
     @Override
     public Material getMaterial() {
-        return Material.GROUND;
+        if (requireTool) { return Material.STONE; }
+        else { return Material.GROUND; }
     }
 
     @Override
@@ -185,12 +189,12 @@ public class SubBlockOreSamplePart extends SubBlockPart {
     public boolean onBlockActivated(World world, BlockPos pos, EntityPlayer player) {
         if (activatedText != null && !activatedText.isEmpty()) {
             player.sendStatusMessage(new TextComponentString(activatedText), true);
-        } else {
+            world.setBlockToAir(pos);
+        } else if (!requireTool) {
             spawnItemStackEntity(world, this.getItemStack().copy(), pos);
+            world.setBlockToAir(pos);
         }
-        world.setBlockToAir(pos);
         player.swingArm(EnumHand.MAIN_HAND);
         return true;
     }
 }
-

--- a/src/main/java/com/teamacronymcoders/base/materialsystem/partdata/DataPartParsers.java
+++ b/src/main/java/com/teamacronymcoders/base/materialsystem/partdata/DataPartParsers.java
@@ -1,6 +1,10 @@
 package com.teamacronymcoders.base.materialsystem.partdata;
 
 public class DataPartParsers {
+    public static boolean getBool(String value) {
+        return Boolean.parseBoolean(value);
+    }
+    
     public static float getFloat(String value) {
         return Float.parseFloat(value);
     }

--- a/src/main/java/com/teamacronymcoders/base/materialsystem/parttype/OrePartType.java
+++ b/src/main/java/com/teamacronymcoders/base/materialsystem/parttype/OrePartType.java
@@ -2,6 +2,7 @@ package com.teamacronymcoders.base.materialsystem.parttype;
 
 import com.google.common.collect.Lists;
 import com.teamacronymcoders.base.materialsystem.MaterialUser;
+import com.teamacronymcoders.base.materialsystem.MaterialSystem;
 import com.teamacronymcoders.base.materialsystem.blocks.SubBlockOrePart;
 import com.teamacronymcoders.base.materialsystem.materialparts.MaterialPart;
 import com.teamacronymcoders.base.materialsystem.partdata.MaterialPartData;
@@ -70,6 +71,7 @@ public class OrePartType extends BlockPartType {
                 variantMaterialPart.setColorized(materialPart.isColorized());
                 materialUser.registerMaterialPart(variantMaterialPart);
             }
+            MaterialSystem.removeMaterialPart(materialPart);
         } else {
             registerSubBlock(materialPart, new SubBlockOrePart(materialPart, new ResourceLocation("stone"),
                     materialUser));

--- a/src/main/java/com/teamacronymcoders/base/materialsystem/parttype/OreSamplePartType.java
+++ b/src/main/java/com/teamacronymcoders/base/materialsystem/parttype/OreSamplePartType.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 public class OreSamplePartType extends BlockPartType {
     public static final String DROP_DATA_NAME = "drops";
+    public static final String REQUIRE_TOOL_DATA_NAME = "requireTool";
     public static final String ACTIVATED_TEXT_DATA_NAME = "activatedText";
 
     public OreSamplePartType() {
@@ -19,6 +20,7 @@ public class OreSamplePartType extends BlockPartType {
     private static List<PartDataPiece> setupOreSampleData() {
         List<PartDataPiece> oreDataPieces = Lists.newArrayList();
         oreDataPieces.add(new PartDataPiece(DROP_DATA_NAME, false));
+        oreDataPieces.add(new PartDataPiece(REQUIRE_TOOL_DATA_NAME, false));
         oreDataPieces.add(new PartDataPiece(ACTIVATED_TEXT_DATA_NAME, false));
         return oreDataPieces;
     }

--- a/src/main/java/com/teamacronymcoders/base/subblocksystem/blocks/SubBlockBase.java
+++ b/src/main/java/com/teamacronymcoders/base/subblocksystem/blocks/SubBlockBase.java
@@ -84,6 +84,10 @@ public abstract class SubBlockBase implements ISubBlock {
         return this.block.getDefaultState().withProperty(BlockSubBlockHolder.SUB_BLOCK_NUMBER, meta);
     }
     
+    public Block getBlock() {
+        return block;
+    }
+    
     @Override
     public void setBlock(Block block) {
         this.block = block;


### PR DESCRIPTION
Add (boolean) "requireTool" data value to ore samples to control whether they need tools for their drops.
OreParts created with variants remove the non-variant MaterialPart from MaterialSystem after creating all variants.