### PR TITLE
Address The-Acronym-Coders/ContentTweaker#106

### DIFF
--- a/src/main/java/com/teamacronymcoders/base/materialsystem/items/ItemMaterialArmor.java
+++ b/src/main/java/com/teamacronymcoders/base/materialsystem/items/ItemMaterialArmor.java
@@ -59,8 +59,8 @@ public class ItemMaterialArmor extends ItemArmor implements IHasModel, IHasItemC
     public String getItemStackDisplayName(@Nonnull ItemStack itemStack) {
         //noinspection deprecation
         String materialName;
-        if (I18n.canTranslate(this.materialPart.getMaterial().getUnlocalizedName())) {
-            materialName = I18n.translateToLocal(this.materialPart.getMaterial().getUnlocalizedName());
+        if (I18n.canTranslate(this.materialPart.getMaterial().getTranslationKey())) {
+            materialName = I18n.translateToLocal(this.materialPart.getMaterial().getTranslationKey());
         } else {
             materialName = this.materialPart.getMaterial().getName();
         }

--- a/src/main/java/com/teamacronymcoders/base/materialsystem/items/ItemMaterialArmor.java
+++ b/src/main/java/com/teamacronymcoders/base/materialsystem/items/ItemMaterialArmor.java
@@ -58,9 +58,15 @@ public class ItemMaterialArmor extends ItemArmor implements IHasModel, IHasItemC
     @Nonnull
     public String getItemStackDisplayName(@Nonnull ItemStack itemStack) {
         //noinspection deprecation
+        String materialName;
+        if (I18n.canTranslate(this.materialPart.getMaterial().getUnlocalizedName())) {
+            materialName = I18n.translateToLocal(this.materialPart.getMaterial().getUnlocalizedName());
+        } else {
+            materialName = this.materialPart.getMaterial().getName();
+        }
         return I18n.translateToLocalFormatted(this.materialPart.getPart()
                         .getUnlocalizedName() + "." + this.armorType.getName(),
-                this.materialPart.getMaterial().getName());
+                materialName);
     }
 
     @Override

--- a/src/main/java/com/teamacronymcoders/base/materialsystem/materialparts/MaterialPart.java
+++ b/src/main/java/com/teamacronymcoders/base/materialsystem/materialparts/MaterialPart.java
@@ -56,8 +56,8 @@ public class MaterialPart {
 
     public String getLocalizedName() {
         //noinspection deprecation
-        if (I18n.canTranslate(material.getUnlocalizedName())) {
-            String materialDisplayName = I18n.translateToLocal(material.getUnlocalizedName());
+        if (I18n.canTranslate(material.getTranslationKey())) {
+            String materialDisplayName = I18n.translateToLocal(material.getTranslationKey());
             return I18n.translateToLocalFormatted(part.getUnlocalizedName(), materialDisplayName);
         } else {
             return I18n.translateToLocalFormatted(part.getUnlocalizedName(), material.getName());

--- a/src/main/java/com/teamacronymcoders/base/materialsystem/materialparts/MaterialPart.java
+++ b/src/main/java/com/teamacronymcoders/base/materialsystem/materialparts/MaterialPart.java
@@ -56,7 +56,12 @@ public class MaterialPart {
 
     public String getLocalizedName() {
         //noinspection deprecation
-        return I18n.translateToLocalFormatted(part.getUnlocalizedName(), material.getName());
+        if (I18n.canTranslate(material.getUnlocalizedName())) {
+            String materialDisplayName = I18n.translateToLocal(material.getUnlocalizedName());
+            return I18n.translateToLocalFormatted(part.getUnlocalizedName(), materialDisplayName);
+        } else {
+            return I18n.translateToLocalFormatted(part.getUnlocalizedName(), material.getName());
+        }
     }
 
     public boolean hasEffect() {

--- a/src/main/java/com/teamacronymcoders/base/materialsystem/materials/Material.java
+++ b/src/main/java/com/teamacronymcoders/base/materialsystem/materials/Material.java
@@ -36,6 +36,6 @@ public class Material {
     }
 
     public String getUnlocalizedName() {
-        return unlocalizedName;
+        return "base.material." + unlocalizedName;
     }
 }

--- a/src/main/java/com/teamacronymcoders/base/materialsystem/materials/Material.java
+++ b/src/main/java/com/teamacronymcoders/base/materialsystem/materials/Material.java
@@ -36,6 +36,10 @@ public class Material {
     }
 
     public String getUnlocalizedName() {
+        return unlocalizedName;
+    }
+
+    public String getTranslationKey() {
         return "base.material." + unlocalizedName;
     }
 }


### PR DESCRIPTION
This commit does the following:

  1. Change implementation of `MaterialPart::getLocalizedName`, so that it checks whether the material name is translatable first, and if so, use the translation, otherwise, fallback to `Material::getName`.
  2. Change implementation of `ItemMaterialArmor::getItemStackDisplayName` in a similar way to that of what 1. describes.
  3. ~~Change implementation of `Material::getUnlocalizedName`, to include `base.material.` prefix.~~ Add `Material::getTranslationKey` for translatability check in 1. and 2.; it also functions as a pure accessor of translation key of `Material`. 

As mentioned in The-Acronym-Coders/ContentTweaker#106, `I18n.canTranslate` is not an expensive call, and translated name is only required in places like item tooltip and HUD, so there is no performance issue in this solution.