### PR TITLE
Changing ore rendering from translucent to cutout.

### DIFF
--- a/src/main/java/com/teamacronymcoders/base/materialsystem/blocks/SubBlockOrePart.java
+++ b/src/main/java/com/teamacronymcoders/base/materialsystem/blocks/SubBlockOrePart.java
@@ -78,7 +78,7 @@ public class SubBlockOrePart extends SubBlockPart {
     
     @Override
     public BlockRenderLayer getRenderLayer() {
-    	return BlockRenderLayer.TRANSLUCENT;
+    	return BlockRenderLayer.CUTOUT;
     }
 
 }


### PR DESCRIPTION
This fixes some rendering issues where:
- The ore shows up in front of rain that should be visible between you and the ore.
- Particle effects are visible through the ore
- Large walls of ore (e.g. Geolosys/GregTech generation) cause excessive rendering lag and weird artifacting at block edges.