### PR TITLE
Enable alternative namespaces

### DIFF
--- a/src/main/java/com/teamacronymcoders/base/registrysystem/BlockRegistry.java
+++ b/src/main/java/com/teamacronymcoders/base/registrysystem/BlockRegistry.java
@@ -11,18 +11,28 @@ public class BlockRegistry extends ModularRegistry<Block> {
     public BlockRegistry(IBaseMod mod, List<IRegistryPiece> registryPieces) {
         super("BLOCK", mod, registryPieces);
     }
+    
+    public BlockRegistry(IBaseMod mod, List<IRegistryPiece> registryPieces, String altNamespace) {
+        super("BLOCK", mod, registryPieces);
+    }
 
     public void register(Block block) {
+        String namespace = new String();
+        if (altNamespace == null) {
+            namespace = mod.getID();
+        } else {
+            namespace = altNamespace;   
+        }
         String unlocalizedName = block.getTranslationKey();
         if (unlocalizedName.startsWith("tile.")) {
             unlocalizedName = unlocalizedName.substring(5);
         }
-        if (!unlocalizedName.contains(mod.getID())) {
-            block.setTranslationKey(mod.getID() + "." + unlocalizedName);
+        if (!unlocalizedName.contains(namespace)) {
+            block.setTranslationKey(namespace + "." + unlocalizedName);
         }
         ResourceLocation name = block.getRegistryName();
         if (name == null) {
-            name = new ResourceLocation(this.mod.getID(), unlocalizedName);
+            name = new ResourceLocation(namespace, unlocalizedName);
         }
 
         this.register(name, block);

--- a/src/main/java/com/teamacronymcoders/base/registrysystem/BlockRegistry.java
+++ b/src/main/java/com/teamacronymcoders/base/registrysystem/BlockRegistry.java
@@ -17,12 +17,7 @@ public class BlockRegistry extends ModularRegistry<Block> {
     }
 
     public void register(Block block) {
-        String namespace = new String();
-        if (altNamespace == null) {
-            namespace = mod.getID();
-        } else {
-            namespace = altNamespace;   
-        }
+        String namespace = (altNamespace != null) ? altNamespace : mod.getID();
         String unlocalizedName = block.getTranslationKey();
         if (unlocalizedName.startsWith("tile.")) {
             unlocalizedName = unlocalizedName.substring(5);

--- a/src/main/java/com/teamacronymcoders/base/registrysystem/EntityRegistry.java
+++ b/src/main/java/com/teamacronymcoders/base/registrysystem/EntityRegistry.java
@@ -12,9 +12,14 @@ public class EntityRegistry extends ModularRegistry<ExtendedEntityEntry> {
     public EntityRegistry(IBaseMod mod, List<IRegistryPiece> registryPieces) {
         super("ENTITY", mod, registryPieces);
     }
+    
+    public EntityRegistry(IBaseMod mod, List<IRegistryPiece> registryPieces, String altNamespace) {
+        super("ENTITY", mod, registryPieces);
+    }
 
     public void register(Class<? extends Entity> entityClass) {
-        ResourceLocation name = new ResourceLocation(this.mod.getID(), entityClass.getSimpleName());
+        String namespace = (altNamespace != null) ? altNamespace : mod.getID();
+        ResourceLocation name = new ResourceLocation(namespace, entityClass.getSimpleName());
         ExtendedEntityEntry extendedEntityEntry = new ExtendedEntityEntry(entityClass, name.toString());
         register(name, extendedEntityEntry);
     }

--- a/src/main/java/com/teamacronymcoders/base/registrysystem/ItemRegistry.java
+++ b/src/main/java/com/teamacronymcoders/base/registrysystem/ItemRegistry.java
@@ -28,7 +28,6 @@ public class ItemRegistry extends ModularRegistry<Item> {
         }
         if (!unlocalizedName.contains(namespace)) {
             item.setTranslationKey(namespace + "." + unlocalizedName);
-            }
         }
         ResourceLocation name = item.getRegistryName();
         if (name == null) {

--- a/src/main/java/com/teamacronymcoders/base/registrysystem/ItemRegistry.java
+++ b/src/main/java/com/teamacronymcoders/base/registrysystem/ItemRegistry.java
@@ -18,12 +18,7 @@ public class ItemRegistry extends ModularRegistry<Item> {
     }
     
     public void register(Item item) {
-        String namespace = new String();
-        if altNamespace == null {
-            namespace = mod.getID();
-        } else {
-            namespace = altNamespace;
-        }
+        String namespace = (altNamespace != null) ? altNamespace : mod.getID();
         String unlocalizedName = item.getTranslationKey();
         if (unlocalizedName.startsWith("item.")) {
             unlocalizedName = unlocalizedName.substring(5);

--- a/src/main/java/com/teamacronymcoders/base/registrysystem/ItemRegistry.java
+++ b/src/main/java/com/teamacronymcoders/base/registrysystem/ItemRegistry.java
@@ -12,8 +12,18 @@ public class ItemRegistry extends ModularRegistry<Item> {
     public ItemRegistry(IBaseMod mod, List<IRegistryPiece> registryPieces) {
         super("ITEM", mod, registryPieces);
     }
-
+    
+    public ItemRegistry(IBaseMod mod, List<IRegistryPiece> registryPieces, String altNamespace) {
+        super("ITEM", mod, registryPieces);
+    }
+    
     public void register(Item item) {
+        String namespace = new String();
+        if altNamespace == null {
+            namespace = mod.getID();
+        } else {
+            namespace = altNamespace;
+        }
         String unlocalizedName = item.getTranslationKey();
         if (unlocalizedName.startsWith("item.")) {
             unlocalizedName = unlocalizedName.substring(5);
@@ -21,12 +31,13 @@ public class ItemRegistry extends ModularRegistry<Item> {
                 throw new RuntimeException("Unlocalized Name cannot be null");
             }
         }
-        if (!unlocalizedName.contains(mod.getID())) {
-            item.setTranslationKey(mod.getID() + "." + unlocalizedName);
+        if (!unlocalizedName.contains(namespace)) {
+            item.setTranslationKey(namespace + "." + unlocalizedName);
+            }
         }
         ResourceLocation name = item.getRegistryName();
         if (name == null) {
-            name = new ResourceLocation(this.mod.getID(), unlocalizedName);
+            name = new ResourceLocation(namespace, unlocalizedName);
         }
 
         this.register(name, item);


### PR DESCRIPTION
This will (hopefully) enable mods (read: ContentTweaker) to use alternative namespaces in the registered `ResourceLocation` when easy-registering blocks, items or entities. This opens up a world of (I can think of 2) possibilities, like overrides and splitting a large mod into multiple chunks. Also null-safe and completely optional for the modder side. CoT will also get an update PR to take advantage of this.